### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Pull in the package using Composer
 
     composer require jamesmills/watchable
 
+> **Note**: If you are using Laravel 5.5, the next step for provider are unnecessary. Laravel Watchable supports Laravel [Package Discovery](https://laravel.com/docs/5.5/packages#package-discovery).
+
 Include the service provider within `app/config/app.php`.
 
 ```php


### PR DESCRIPTION
Explicit that Laravel Watchable supports package discovery out of the box in README file