### PR TITLE
Replaced linter with the php-cs-fixer lint functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ fix:
 	$(HERE)/vendor/bin/php-cs-fixer fix --config=$(HERE)/.php_cs
 
 lint:
-	find -L $(HERE)/src -name '*.php' -print0 | xargs -0 -n1 php -l > /dev/null
-	find -L $(HERE)/migrations -name '*.php' -print0 | xargs -0 -n1 php -l > /dev/null
+	$(HERE)/vendor/bin/php-cs-fixer fix --config=$(HERE)/.php_cs --dry-run
 
-test: fix lint
+test: lint

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,6 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.5"
+        "friendsofphp/php-cs-fixer": "^2.0"
     }
 }


### PR DESCRIPTION
This replaces the built-in linter with the php-cs-fixer version and enforces a non-zero exit code on failure.