### PR TITLE
Add optional userids

### DIFF
--- a/src/Models/Watch.php
+++ b/src/Models/Watch.php
@@ -40,6 +40,11 @@ class Watch extends Model
         return $this->morphTo();
     }
 
+    /**
+     * User model relation.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
     public function user()
     {
         return $this->belongsTo(User::class);

--- a/src/Traits/Watchable.php
+++ b/src/Traits/Watchable.php
@@ -33,12 +33,12 @@ trait Watchable
     /**
      * Set the user as a watcher.
      *
-     * @param null|int $userId
+     * @param null|int $user_id
      */
-    public function watch($userId = null)
+    public function watch($user_id = null)
     {
         $watch = $this->watchers()->firstOrNew([
-            'user_id' => $userId ?? auth()->id(),
+            'user_id' => $user_id ?? auth()->id(),
         ]);
 
         $watch->save();
@@ -47,12 +47,12 @@ trait Watchable
     /**
      * Unwatch the given model for the user.
      *
-     * @param null|int $userId
+     * @param null|int $user_id
      */
-    public function unwatch($userId = null)
+    public function unwatch($user_id = null)
     {
         $watch = $this->watchers()
-            ->where('user_id', '=', $userId ?? auth()->id())
+            ->where('user_id', '=', $user_id ?? auth()->id())
             ->first();
 
         if ($watch) {
@@ -63,27 +63,27 @@ trait Watchable
     /**
      * Toggle the watch state of a user to the model.
      *
-     * @param null|int $userId
+     * @param null|int $user_id
      */
-    public function toggleWatch($userId = null)
+    public function toggleWatch($user_id = null)
     {
-        if ($this->isWatched($userId)) {
-            $this->unwatch($userId);
+        if ($this->isWatched($user_id)) {
+            $this->unwatch($user_id);
         } else {
-            $this->watch($userId);
+            $this->watch($user_id);
         }
     }
 
     /**
      * Check if a user is watching a model.
      *
-     * @param null|int $userId
+     * @param null|int $user_id
      * @return bool
      */
-    public function isWatched($userId = null)
+    public function isWatched($user_id = null)
     {
         return (bool) $this->watchers()
-            ->where('user_id', '=', $userId ?? auth()->id())
+            ->where('user_id', '=', $user_id ?? auth()->id())
             ->count();
     }
 }

--- a/src/Traits/Watchable.php
+++ b/src/Traits/Watchable.php
@@ -17,7 +17,7 @@ trait Watchable
     }
 
     /**
-     * Get a collection of user models who watch the igven model.
+     * Get a collection of user models who watch the given model.
      *
      * @return mixed
      */

--- a/src/Traits/Watchable.php
+++ b/src/Traits/Watchable.php
@@ -31,24 +31,28 @@ trait Watchable
     }
 
     /**
-     * Set the current user as a watcher.
+     * Set the user as a watcher.
+     *
+     * @param null|int $userId
      */
-    public function watch()
+    public function watch($userId = null)
     {
         $watch = $this->watchers()->firstOrNew([
-            'user_id' => auth()->id(),
+            'user_id' => $userId ?? auth()->id(),
         ]);
 
         $watch->save();
     }
 
     /**
-     * Unwatch the given model for the current user.
+     * Unwatch the given model for the user.
+     *
+     * @param null|int $userId
      */
-    public function unwatch()
+    public function unwatch($userId = null)
     {
         $watch = $this->watchers()
-            ->where('user_id', '=', auth()->id())
+            ->where('user_id', '=', $userId ?? auth()->id())
             ->first();
 
         if ($watch) {
@@ -58,25 +62,28 @@ trait Watchable
 
     /**
      * Toggle the watch state of a user to the model.
+     *
+     * @param null|int $userId
      */
-    public function toggleWatch()
+    public function toggleWatch($userId = null)
     {
-        if ($this->isWatched()) {
-            $this->unwatch();
+        if ($this->isWatched($userId)) {
+            $this->unwatch($userId);
         } else {
-            $this->watch();
+            $this->watch($userId);
         }
     }
 
     /**
      * Check if a user is watching a model.
      *
+     * @param null|int $userId
      * @return bool
      */
-    public function isWatched()
+    public function isWatched($userId = null)
     {
         return (bool) $this->watchers()
-            ->where('user_id', '=', auth()->id())
+            ->where('user_id', '=', $userId ?? auth()->id())
             ->count();
     }
 }


### PR DESCRIPTION
I've added an optional `$user_id` parameter to the methods referencing `auth()->id()`. This will allow a developer to specify a specific user if needed. This could be useful for backfilling an application.